### PR TITLE
Add linking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ If `GHQ_MIGRATOR_PREFER_ORIGIN=1` is set, ghq-migrator moves the repository acco
 
 *Note* : Even if `GHQ_MIGRATOR_PREFER_ORIGIN=1` is specified, ghq-migrator cannot move repositories which its origin has more than 2 urls, because ghq-migrator cannot decide which url to use.
 
+### `GHQ_MIGRATOR_LINK`
+
+If `GHQ_MIGRATOR_LINK=1` is set, a symbolic link to the destination directory will be created at the place where the repository was moved from.
+
 ### AUTHOR
 
 astj (asato.wakisaka@gmail.com)

--- a/ghq-migrator.bash
+++ b/ghq-migrator.bash
@@ -34,6 +34,11 @@ function _move_repository_directory {
     REMOTE_PATH=$2
 
     echo "move this repository to ${GHQ_ROOT}/${REMOTE_PATH}"
+
+    if [ ${GHQ_MIGRATOR_LINK:-0} -eq 1 ]; then
+        echo "create a link from ${TARGET_DIR%/} to ${GHQ_ROOT}/${REMOTE_PATH}"
+    fi
+
     if [ ${GHQ_MIGRATOR_ACTUALLY_RUN:-0} -eq 1 ]; then
         NEW_REPO_DIR="${GHQ_ROOT}/${REMOTE_PATH}"
         if [ -e $NEW_REPO_DIR ]; then
@@ -42,6 +47,10 @@ function _move_repository_directory {
         fi
         mkdir -p "${NEW_REPO_DIR%/*}"
         mv ${TARGET_DIR%/} $NEW_REPO_DIR
+
+        if [ ${GHQ_MIGRATOR_LINK:-0} -eq 1 ]; then
+            ln -s ${NEW_REPO_DIR} ${TARGET_DIR%/}
+        fi
     else
         echo 'specify GHQ_MIGRATOR_ACTUALLY_RUN=1 to work actually'
     fi


### PR DESCRIPTION
Thanks for the useful script.

### Background

I feel like migrating my working directory to ghq style, but I also want to keep the original directory structure while moving the repositories into the ghq root.

### Changes

Added a new env named `GHQ_MIGRATOR_LINK` and updated the readme. This env activates the linking feature and `ln` command will be called internally to create the symbolic link.